### PR TITLE
Using npm_config_* environment variables instead of sourcing npmrc

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,14 @@
 'use strict';
 
-var conf = require('rc')('npm');
 
 module.exports = function () {
 	return process.env.HTTPS_PROXY ||
 		process.env.https_proxy ||
 		process.env.HTTP_PROXY ||
 		process.env.http_proxy ||
-		conf['https-proxy'] ||
-		conf['http-proxy'] ||
-		conf.proxy ||
+		process.env.ALL_PROXY ||
+		process.env.all_proxy ||
+		process.env.npm_config_https_proxy ||
+		process.env.npm_config_proxy ||
 		null;
 };

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   ],
   "keywords": [],
   "dependencies": {
-    "rc": "^0.5.5"
   },
   "devDependencies": {
     "ava": "^0.0.4"


### PR DESCRIPTION
Hi,

I noticed you are using only the .npmrc file, but not the values that can be passed to npm via cli arguments. This PR switches that. Let me know your thoughts.

Thanks,
Albert
